### PR TITLE
Refactor Syncotrope to use Uint8Array API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { downloadBuffer } from "./util/buffer-download";
 import { Syncotrope } from "./core/syncotrope";
 import type { FFmpeg as FFmpegClass } from "@ffmpeg/ffmpeg";
+import { fetchFile } from "@ffmpeg/util";
 import { setupSettingsSidebar } from "./ui/settings-sidebar";
 import { setProgress } from "./ui/progress-bar";
 
@@ -13,21 +14,21 @@ const processFiles = async (event: Event) => {
   const files = (event.target as HTMLInputElement)?.files;
 
   if (!files?.length) {
-    throw new Error("Cannt find file uploaded");
+    throw new Error("Cannot find file uploaded");
   }
 
   syncotrope.loadSettings();
 
   for (const file of files) {
     setProgress(0.1);
-    const originalImage = await syncotrope.fs.loadFile(file);
-    const overlaidImage = await syncotrope.standardizeImage(originalImage);
-    const videoFile = await syncotrope.combinedZoomAndVideo(overlaidImage);
-    const outfile = await syncotrope.fs.getFile(videoFile.name);
+
+    // Convert File to Uint8Array and process with the simplified API
+    const imageData = await fetchFile(file);
+    const videoData = await syncotrope.processImage(imageData);
 
     setProgress(100);
 
-    downloadBuffer(outfile, "output.mp4", "video/mp4");
+    downloadBuffer(videoData, "output.mp4", "video/mp4");
   }
 };
 


### PR DESCRIPTION
## Summary
- Add `processImage()` and `processImages()` as the main public API
- Make internal methods private (standardizeImage, scaleImage, etc.)
- Hide FileReference abstraction as implementation detail
- Update index.ts to use the simplified API

Consumers now only deal with `Uint8Array` buffers instead of the internal `FileReference` type.

## Test plan
- [x] All existing tests pass
- [x] Build succeeds
- [ ] Manual test: upload image and verify video output works

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)