### PR TITLE
Add multi-file upload with video concatenation

### DIFF
--- a/src/core/ffmpeg-filters.test.ts
+++ b/src/core/ffmpeg-filters.test.ts
@@ -7,6 +7,7 @@ import {
   buildScaleFilter,
   buildBlurFilter,
   buildOverlayFilter,
+  buildConcatList,
   ZoompanParams,
 } from "./ffmpeg-filters";
 import { ZoomSettings } from "./zoom";
@@ -289,5 +290,30 @@ describe("settings to filter integration", () => {
     assert.ok(filter.includes("d="));
     assert.ok(filter.includes("fps="));
     assert.ok(filter.includes("s="));
+  });
+});
+
+describe("buildConcatList", () => {
+  it("builds correct format for single file", () => {
+    const list = buildConcatList(["video1.mp4"]);
+    assert.strictEqual(list, "file 'video1.mp4'");
+  });
+
+  it("builds correct format for multiple files", () => {
+    const list = buildConcatList(["video1.mp4", "video2.mp4", "video3.mp4"]);
+    assert.strictEqual(
+      list,
+      "file 'video1.mp4'\nfile 'video2.mp4'\nfile 'video3.mp4'",
+    );
+  });
+
+  it("returns empty string for empty array", () => {
+    const list = buildConcatList([]);
+    assert.strictEqual(list, "");
+  });
+
+  it("handles filenames with special characters", () => {
+    const list = buildConcatList(["video-1.mp4", "video_2.mp4"]);
+    assert.strictEqual(list, "file 'video-1.mp4'\nfile 'video_2.mp4'");
   });
 });

--- a/src/core/ffmpeg-filters.ts
+++ b/src/core/ffmpeg-filters.ts
@@ -98,3 +98,11 @@ export function buildOverlayFilter(
 ): string {
   return `[0:v][1:v]overlay=(${targetWidth}/2)-(overlay_w/2):0,crop=${targetWidth}:${targetHeight}:0:0[outv]`;
 }
+
+/**
+ * Build concat list file content for FFmpeg's concat demuxer.
+ * @param filenames - Array of video filenames to concatenate
+ */
+export function buildConcatList(filenames: string[]): string {
+  return filenames.map((f) => `file '${f}'`).join("\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,17 +27,28 @@ const processFiles = async (event: Event) => {
   const mimeType = getMimeType(settings.outputFormat);
   const outputFilename = `output.${settings.outputFormat}`;
 
-  for (const file of files) {
-    setProgress(0.1);
+  const videoDataList: Uint8Array[] = [];
+  const totalFiles = files.length;
+
+  // Process each image into a video clip
+  for (let i = 0; i < totalFiles; i++) {
+    const file = files[i];
+    const progressBase = (i / totalFiles) * 90; // Reserve 10% for concatenation
+    setProgress(progressBase + 1);
 
     // Convert File to Uint8Array and process with the simplified API
     const imageData = await fetchFile(file);
     const videoData = await syncotrope.processImage(imageData);
-
-    setProgress(100);
-
-    downloadBuffer(videoData, outputFilename, mimeType);
+    videoDataList.push(videoData);
   }
+
+  // Concatenate all videos if there are multiple
+  setProgress(92);
+  const finalVideo = await syncotrope.concatenateVideos(videoDataList);
+
+  setProgress(100);
+
+  downloadBuffer(finalVideo, outputFilename, mimeType);
 };
 
 export function setup() {


### PR DESCRIPTION
## Summary
- Add `concatenateVideos()` method to Syncotrope class
- Add `buildConcatList()` helper for FFmpeg concat demuxer format
- Update index.ts to process all files and stitch videos together
- Add tests for buildConcatList()

When multiple images are uploaded, each is processed into a video clip, then all clips are concatenated into a single output video using FFmpeg's concat demuxer.

## Test plan
- [x] All tests pass (115 tests)
- [x] Build succeeds
- [ ] Manual test: upload multiple images and verify single concatenated video output

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)