### PR TITLE
Add comprehensive edge case tests for zoom and filter systems

### DIFF
--- a/src/core/zoom.test.ts
+++ b/src/core/zoom.test.ts
@@ -345,6 +345,93 @@ describe("isNearInteger", () => {
   });
 });
 
+describe("edge cases", () => {
+  it("handles very small zoom rate (1.001)", () => {
+    const settings: ZoomSettings = {
+      zoomRate: 1.001,
+      frameRate: 25,
+      imageDurationSeconds: 3,
+      targetWidth: 1920,
+      targetHeight: 1080,
+    };
+    const zoom = finalZoomLevel(settings);
+    // 1 + 0.001 * 75 = 1.075
+    assert.ok(Math.abs(zoom - 1.075) < 0.0001, `Expected 1.075, got ${zoom}`);
+  });
+
+  it("handles high frame rate (60fps)", () => {
+    const settings: ZoomSettings = {
+      zoomRate: 1.005,
+      frameRate: 60,
+      imageDurationSeconds: 3,
+      targetWidth: 1920,
+      targetHeight: 1080,
+    };
+    const zoom = finalZoomLevel(settings);
+    // 1 + 0.005 * 180 = 1.9
+    assert.ok(Math.abs(zoom - 1.9) < 0.0001, `Expected 1.9, got ${zoom}`);
+  });
+
+  it("handles short duration (1 second)", () => {
+    const settings: ZoomSettings = {
+      zoomRate: 1.005,
+      frameRate: 25,
+      imageDurationSeconds: 1,
+      targetWidth: 1920,
+      targetHeight: 1080,
+    };
+    const zoom = finalZoomLevel(settings);
+    // 1 + 0.005 * 25 = 1.125
+    assert.ok(Math.abs(zoom - 1.125) < 0.0001, `Expected 1.125, got ${zoom}`);
+  });
+
+  it("handles long duration (10 seconds)", () => {
+    const settings: ZoomSettings = {
+      zoomRate: 1.005,
+      frameRate: 25,
+      imageDurationSeconds: 10,
+      targetWidth: 1920,
+      targetHeight: 1080,
+    };
+    const zoom = finalZoomLevel(settings);
+    // 1 + 0.005 * 250 = 2.25
+    assert.ok(Math.abs(zoom - 2.25) < 0.0001, `Expected 2.25, got ${zoom}`);
+  });
+
+  it("handles 4K resolution", () => {
+    const settings: ZoomSettings = {
+      zoomRate: 1.005,
+      frameRate: 25,
+      imageDurationSeconds: 3,
+      targetWidth: 3840,
+      targetHeight: 2160,
+    };
+    const dims = upscaledDimensions(settings);
+    // finalZoom = 1.375
+    assert.ok(
+      Math.abs(dims.width - 3840 * 1.375) < 0.01,
+      `Expected ${3840 * 1.375}, got ${dims.width}`,
+    );
+    assert.ok(
+      Math.abs(dims.height - 2160 * 1.375) < 0.01,
+      `Expected ${2160 * 1.375}, got ${dims.height}`,
+    );
+  });
+
+  it("handles non-16:9 aspect ratio", () => {
+    const settings: ZoomSettings = {
+      zoomRate: 1.005,
+      frameRate: 25,
+      imageDurationSeconds: 3,
+      targetWidth: 1080,
+      targetHeight: 1080, // Square
+    };
+    const dims = upscaledDimensions(settings);
+    // Should maintain square aspect ratio
+    assert.strictEqual(dims.width, dims.height);
+  });
+});
+
 describe("analyzeZoomForJitter", () => {
   it("produces no jitter with default settings", () => {
     const settings: ZoomSettings = {


### PR DESCRIPTION
## Summary
- Adds 7 new edge case tests for zoom calculations covering various settings combinations
- Adds 5 new integration tests for filter generation with different resolutions and frame rates
- Adds 2 new overlay filter tests for 4K and square resolutions
- Total of 14 new test cases increasing coverage

Closes #13

## Test plan
- [x] All 122 tests pass
- [x] ESLint and Prettier checks pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)